### PR TITLE
Pull out Ashlar server into its own repo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,38 @@
+# .env.example -- Example environmental variables for an Ashlar server project.
+# To override any of these variables, copy this file to .env and make sure that whatever
+# runs your process (e.g. Docker Compose or supervisord) knows to load these
+# variables into the environment.
+
+# Standard Django settings file variables. For more context, see the Django
+# documentation on what each of these does:
+# https://docs.djangoproject.com/en/dev/ref/settings/
+SECRET_KEY=super-duper-secret
+DEBUG=True
+
+# Comma-separated string of hosts that are allowed to serve the app. When
+# DEBUG=True this can be empty. For more context, see the docs:
+# https://docs.djangoproject.com/en/dev/ref/settings/#allowed-hosts
+ALLOWED_HOSTS=
+
+# Special flag to tell Ashlar whether or not you're developing locally.
+DEVELOP=True
+
+# Optionally override Django database connections. If you're using the services
+# defined in this repo's docker-compose.yml file, you shouldn't have to change
+# these variables at all.
+DB_NAME=postgres
+DB_USER=postgres
+DB_HOST=db
+DB_PASS=
+DB_PORT=5432
+
+# Default admin credentials that get created during the first migration of
+# Ashlar's authentication system
+DEFAULT_ADMIN_EMAIL=systems+ashlar@azavea.com
+DEFAULT_ADMIN_USERNAME=admin
+DEFAULT_ADMIN_PASSWORD=admin
+
+# Names for different permissions groups
+ASHLAR_READ_ONLY_GROUP=public
+ASHLAR_READ_WRITE_GROUP=staff
+ASHLAR_ADMIN_GROUP=admin

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,65 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Shell
+.env
+
+# MacOS
+.DS_STORE/
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Sphinx documentation
+docs/_build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+sudo: required
+
+services:
+  - docker
+
+before_install:
+  - cp .env.example ./ashlar/.env
+
+install:
+  - ./scripts/update
+
+script:
+  - ./scripts/test

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,8 @@ RUN pip install -U -r /tmp/requirements.txt
 # Do not buffer output (allows Docker to stream stdout)
 ENV PYTHONUNBUFFERED 0
 
-COPY . /opt/ashlar
-WORKDIR /opt/ashlar
+COPY . /opt/ashlar-server
+WORKDIR /opt/ashlar-server
 
 EXPOSE 8000
 ENTRYPOINT python

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM quay.io/azavea/django:1.11-python3.6-slim
+
+# Install OS-level dependencies for Ashlar
+RUN apt-get update
+RUN apt-get -y autoremove && apt-get install -y \
+	libgeos-dev \
+	binutils \
+	libproj-dev \
+	gdal-bin \
+	git
+
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install -U -r /tmp/requirements.txt
+
+# Do not buffer output (allows Docker to stream stdout)
+ENV PYTHONUNBUFFERED 0
+
+COPY . /opt/ashlar
+WORKDIR /opt/ashlar
+
+EXPOSE 8000
+ENTRYPOINT python
+CMD ['manage.py', 'runserver', '0.0.0.0:8000']

--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# Ashlar server
+
+Run a database server on top of Ashlar.
+
+Once this project is more fleshed out, this README will help document how a user
+can configure an Ashlar server for their own project.

--- a/ashlar_auth/__init__.py
+++ b/ashlar_auth/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'ashlar_auth.apps.AshlarAuthConfig'

--- a/ashlar_auth/apps.py
+++ b/ashlar_auth/apps.py
@@ -1,0 +1,34 @@
+"""
+Override app config to register signal for setting default user group on user creation.
+"""
+from django.apps import AppConfig
+from django.db.models.signals import post_save
+
+
+def add_to_default_group(sender, **kwargs):
+    from django.conf import settings
+    from django.contrib.auth.models import Group
+
+    # Make sure that the settings file is configured properly to allow for
+    # permissioning.
+    if not getattr(settings, 'USER_GROUPS'):
+        raise AttributeError('Could not find the USER_GROUPS config in your settings file.')
+    else:
+        if not settings.USER_GROUPS.get('READ_ONLY'):
+            raise KeyError('The USER_GROUPS variable in your settings file requires a READ_ONLY attribute.')
+
+    READ_GROUP = settings.USER_GROUPS['READ_ONLY']
+
+    user = kwargs["instance"]
+    if kwargs["created"]:
+        group = Group.objects.get(name=READ_GROUP)
+        user.groups.add(group)
+
+
+class AshlarAuthConfig(AppConfig):
+    name = 'ashlar_auth'
+    verbose_name = 'Authentication and permissions for the Ashlar server'
+
+    def ready(self):
+        from django.contrib.auth.models import User
+        post_save.connect(add_to_default_group, sender=User)

--- a/ashlar_auth/migrations/0001_initial.py
+++ b/ashlar_auth/migrations/0001_initial.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+from datetime import datetime
+
+from django.db import models, migrations
+from django.conf import settings
+
+from django.contrib.auth.models import Group, User
+
+
+ADMIN_USER = {
+    'email': settings.DEFAULT_ADMIN_EMAIL,
+    'is_staff': True,
+    'is_superuser': True,
+    'username': settings.DEFAULT_ADMIN_USERNAME,
+    'last_login': datetime(2018, 1, 1)
+}
+
+def create_driver_groups(apps, schema_editor):
+    for group_type in settings.USER_GROUPS:
+        group_name = settings.USER_GROUPS[group_type]
+        group = Group.objects.filter(name=group_name)
+        if len(group) == 0:
+            created_group = Group(name=group_name)
+            created_group.save()
+
+def delete_driver_groups(apps, schema_editor):
+    for group_type in settings.USER_GROUPS:
+        group_name = settings.USER_GROUPS[group_type]
+        try:
+            driver_group = Group.objects.get(name=group_name)
+            driver_group.delete()
+        except Group.DoesNotExist:
+            pass
+
+def create_default_admin(apps, schema_editor):
+    admin_user = User.objects.filter(username=ADMIN_USER['username'])
+    admin_group = Group.objects.get(name=settings.USER_GROUPS['ADMIN'])
+    if len(admin_user) == 0:
+        default_admin = User(**ADMIN_USER)
+        default_admin.set_password(settings.DEFAULT_ADMIN_PASSWORD)
+        default_admin.save()
+        default_admin.groups.add(admin_group)
+        default_admin.save()
+
+def delete_default_admin(apps, schema_editor):
+    try:
+        admin_user = User.objects.get(username=ADMIN_USER['username'])
+        admin_user.delete()
+    except User.DoesNotExist:
+        pass
+
+
+class Migration(migrations.Migration):
+    dependencies = []
+
+    operations = [
+        migrations.RunPython(create_driver_groups, delete_driver_groups),
+        migrations.RunPython(create_default_admin, delete_default_admin),
+    ]

--- a/ashlar_auth/migrations/0002_grant_existing_users_permissions.py
+++ b/ashlar_auth/migrations/0002_grant_existing_users_permissions.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+
+from django.contrib.auth.models import Group, User
+
+
+def add_admin_user_to_admin_group(apps, schema_editor):
+    try:
+        admin_group = Group.objects.get(name=settings.USER_GROUPS['ADMIN'])
+        admin_user = User.objects.get(username=settings.DEFAULT_ADMIN_USERNAME)
+        admin_user.groups.add(admin_group)
+        admin_user.save()
+    except (User.DoesNotExist, Group.DoesNotExist):
+        pass
+
+
+def add_non_admin_users_to_public_group(apps, schema_editor):
+    try:
+        public_group = Group.objects.get(name=settings.USER_GROUPS['READ_ONLY'])
+        non_admin_users = User.objects.exclude(username=settings.DEFAULT_ADMIN_USERNAME)
+        for user in non_admin_users:
+            user.groups.add(public_group)
+            user.save()
+    except (User.DoesNotExist, Group.DoesNotExist):
+        pass
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('ashlar_auth', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_admin_user_to_admin_group, migrations.RunPython.noop),
+        migrations.RunPython(add_non_admin_users_to_public_group, migrations.RunPython.noop),
+    ]

--- a/ashlar_auth/permissions.py
+++ b/ashlar_auth/permissions.py
@@ -1,0 +1,124 @@
+from rest_framework import permissions
+from django.conf import settings
+from django.contrib.auth.models import Group, User
+
+
+# helpers to check for group membership
+ADMIN_GROUP = settings.USER_GROUPS['ADMIN']
+READ_GROUP = settings.USER_GROUPS['READ_ONLY']
+WRITE_GROUP = settings.USER_GROUPS['READ_WRITE']
+
+
+def belongs_to_group(user, group):
+    try:
+        return user.groups.filter(name=group).exists()
+    except (User.DoesNotExist, Group.DoesNotExist):
+        return False
+
+
+def is_reader_or_writer(user):
+    try:
+        return user.groups.filter(name__in=(READ_GROUP, WRITE_GROUP)).exists()
+    except (User.DoesNotExist, Group.DoesNotExist):
+        return False
+
+
+def is_admin_or_writer(user):
+    try:
+        return user.groups.filter(name__in=(ADMIN_GROUP, WRITE_GROUP)).exists()
+    except (User.DoesNotExist, Group.DoesNotExist):
+        return False
+
+
+def is_admin(user):
+    return belongs_to_group(user, ADMIN_GROUP)
+
+
+def is_writer(user):
+    return belongs_to_group(user, WRITE_GROUP)
+
+
+def is_reader(user):
+    return belongs_to_group(user, READ_GROUP)
+
+
+class IsAdminOrReadSelfOnly(permissions.BasePermission):
+    """
+    Permission for User objects.
+
+    Object-level user permission to only allow administrators to GET all users or POST any user;
+    non-administrators have read-only access, to only their own user information.
+    """
+    def has_permission(self, request, view):
+        if not request.user or not request.user.is_authenticated():
+            return False
+
+        if is_admin(request.user):
+            return True
+
+        # ensure non-administrative users have read-only access to list view
+        if view.action == 'detail' or request.method in permissions.SAFE_METHODS:
+            return True
+
+    def has_object_permission(self, request, view, obj):
+        if not request.user or not request.user.is_authenticated():
+            return False
+
+        if is_admin(request.user):
+            return True
+
+        # read-only access to one's own user object for non-admin users
+        if request.method in permissions.SAFE_METHODS and request.user == obj:
+            return True
+
+        return False
+
+
+class IsAdminOrReadOnly(permissions.BasePermission):
+    """
+    Allow read-only access to authenticated non-administrators (public or analyst roles),
+    and full access only to administrators.
+    """
+    def has_permission(self, request, view):
+        if request.user and request.user.is_authenticated():
+            if is_admin(request.user):
+                return True
+
+            if request.method in permissions.SAFE_METHODS and is_reader_or_writer(request.user):
+                return True
+
+        return False
+
+
+class IsAdminAndReadOnly(permissions.BasePermission):
+    """
+    Allow read-only access to administrators; entries should be immutable
+    """
+    def has_permission(self, request, view):
+        if request.user and request.user.is_authenticated():
+            if request.method in permissions.SAFE_METHODS and is_admin(request.user):
+                return True
+        return False
+
+
+class ReadersReadWritersWrite(permissions.BasePermission):
+    """
+    Allow read-only access to readers group, and full access to writers or admins.
+    """
+    def has_permission(self, request, view):
+        if not request.user or not request.user.is_authenticated():
+            return False
+
+        if is_admin_or_writer(request.user):
+            return True
+
+        if request.method in permissions.SAFE_METHODS and is_reader(request.user):
+            return True
+
+        return False
+
+
+class IsOwnerOrAdmin(permissions.BasePermission):
+    """Allow access only to the user who created the object, and admins"""
+    def has_object_permission(self, request, view, obj):
+        return obj.owner == request.user or is_admin(request.user)

--- a/ashlar_auth/serializers.py
+++ b/ashlar_auth/serializers.py
@@ -1,0 +1,54 @@
+from django.utils import six
+
+from django.contrib.auth.models import User, Group
+from rest_framework.authtoken.models import Token
+from rest_framework import serializers
+
+
+
+class GroupStringRelatedField(serializers.StringRelatedField):
+    """
+    StringRelatedField in DRF is read-only.
+    Make it writeable for user groups, based on group name.
+    """
+    def to_internal_value(self, data):
+        """
+        Implement this field method so groups field may be writeable
+        """
+        if not isinstance(data, six.text_type):
+            msg = 'Incorrect type. Expected a string, but got %s'
+            raise serializers.ValidationError(msg % type(data).__name__)
+        return Group.objects.get(name=data)
+
+
+class UserSerializer(serializers.ModelSerializer):
+
+    # display groups by name
+    groups = GroupStringRelatedField(many=True)
+
+    class Meta:
+        model = User
+        fields = ('id', 'url', 'username', 'email', 'groups', 'password', 'date_joined',
+                  'is_staff', 'is_superuser',)
+        read_only_fields = ('id',)
+        write_only_fields = ('password',)
+
+    def create(self, validated_data):
+        groups = validated_data.pop('groups')
+        password = validated_data.pop('password')
+        user = User(**validated_data)
+        if user:
+            user.set_password(password)
+            user.save()
+            Token.objects.create(user=user)
+            if groups:
+                user.groups = groups
+                user.save()
+        return user
+
+
+class GroupSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Group
+        fields = ('id', 'url', 'name')
+        read_only_fields = ('id',)

--- a/ashlar_auth/tests.py
+++ b/ashlar_auth/tests.py
@@ -1,5 +1,5 @@
 import json
-from mock import Mock, MagicMock
+from unittest.mock import Mock, MagicMock
 
 from django.conf import settings
 from django.test import TestCase

--- a/ashlar_auth/tests.py
+++ b/ashlar_auth/tests.py
@@ -1,0 +1,122 @@
+import json
+from mock import Mock, MagicMock
+
+from django.conf import settings
+from django.test import TestCase
+from django.contrib.auth.models import User, Group
+from rest_framework.request import Request
+from rest_framework.test import APIClient
+
+from ashlar_auth.permissions import IsOwnerOrAdmin, ReadersReadWritersWrite, IsAdminOrReadOnly
+
+
+class UserViewTestCase(TestCase):
+    def setUp(self):
+        self.public = User.objects.create(username='public')
+
+        self.admin = User.objects.create(username='isAnAdmin')
+        admin_group = Group.objects.get(name=settings.USER_GROUPS['ADMIN'])
+        self.admin.groups.add(admin_group)
+
+        self.client = APIClient()
+
+    def test_get_queryset(self):
+        """Test that queryset includes all users for admins"""
+        url = '/api/users/'
+        self.client.force_authenticate(user=self.admin)
+        response = json.loads(self.client.get(url).content)
+        self.assertEqual(len(response['results']), 3)  # Built-in admin always exists
+        self.client.force_authenticate(user=self.public)
+        response = json.loads(self.client.get(url).content)
+        self.assertEqual(len(response['results']), 1)
+
+
+class PermissionsTestCase(TestCase):
+    def setUp(self):
+        super(PermissionsTestCase, self).setUp()
+
+        self.public_group = Group.objects.get(name=settings.USER_GROUPS['READ_ONLY'])
+        self.public_user = User.objects.create(username='public')
+
+        self.analyst = User.objects.create(username='analyst')
+        analyst_group = Group.objects.get(name=settings.USER_GROUPS['READ_WRITE'])
+        self.analyst.groups.add(analyst_group)
+
+        self.admin = User.objects.get(username=settings.DEFAULT_ADMIN_USERNAME)
+
+        self.request = Mock(spec=Request)
+
+    def tearDown(self):
+        self.public_user.delete()
+        self.analyst.delete()
+
+    def test_default_user_group(self):
+        # new user should belong to public group and public group only by default
+        self.assertEquals(self.public_user.groups.count(), 1)
+        self.assertEquals(self.public_user.groups.first(), self.public_group)
+
+    def test_isowneroradmin(self):
+        owner_or_admin = IsOwnerOrAdmin()
+
+        self.request.user = self.public_user
+        obj = MagicMock()
+        obj.owner = self.public_user
+
+        # non-admin user can access owned object
+        self.assertTrue(owner_or_admin.has_object_permission(self.request, MagicMock(), obj))
+
+        # non-admin cannot access unowned object
+        self.request.user = self.analyst
+        self.assertFalse(owner_or_admin.has_object_permission(self.request, MagicMock(), obj))
+
+        # admin user can access unowned object
+        self.request.user = self.admin
+        self.assertTrue(owner_or_admin.has_object_permission(self.request, MagicMock(), obj))
+
+    def test_readers_read_writers_write(self):
+        readers_writers = ReadersReadWritersWrite()
+
+        # public user can read but not write record
+        self.request.user = self.public_user
+        self.request.method = 'GET'
+        self.assertTrue(readers_writers.has_permission(self.request, MagicMock()))
+        self.request.method = 'POST'
+        self.assertFalse(readers_writers.has_permission(self.request, MagicMock()))
+
+        # writer can read and write record
+        self.request.user = self.analyst
+        self.request.method = 'GET'
+        self.assertTrue(readers_writers.has_permission(self.request, MagicMock()))
+        self.request.method = 'POST'
+        self.assertTrue(readers_writers.has_permission(self.request, MagicMock()))
+
+        # admin can read and write record
+        self.request.user = self.admin
+        self.request.method = 'GET'
+        self.assertTrue(readers_writers.has_permission(self.request, MagicMock()))
+        self.request.method = 'POST'
+        self.assertTrue(readers_writers.has_permission(self.request, MagicMock()))
+
+    def admin_or_readonly(self):
+        admin_or_readonly = IsAdminOrReadOnly()
+
+        # public user can read but not write record
+        self.request.user = self.public_user
+        self.request.method = 'GET'
+        self.assertTrue(admin_or_readonly.has_permission(self.request, MagicMock()))
+        self.request.method = 'POST'
+        self.assertFalse(admin_or_readonly.has_permission(self.request, MagicMock()))
+
+        # analyst can read but not write record
+        self.request.user = self.analyst
+        self.request.method = 'GET'
+        self.assertTrue(admin_or_readonly.has_permission(self.request, MagicMock()))
+        self.request.method = 'POST'
+        self.assertFalse(admin_or_readonly.has_permission(self.request, MagicMock()))
+
+        # admin can read and write record
+        self.request.user = self.admin
+        self.request.method = 'GET'
+        self.assertTrue(admin_or_readonly.has_permission(self.request, MagicMock()))
+        self.request.method = 'POST'
+        self.assertTrue(admin_or_readonly.has_permission(self.request, MagicMock()))

--- a/ashlar_auth/views.py
+++ b/ashlar_auth/views.py
@@ -1,0 +1,64 @@
+import logging
+
+from django.contrib.auth.models import User, Group
+
+from rest_framework import status, viewsets
+from rest_framework.authtoken.models import Token
+from rest_framework.authtoken.views import ObtainAuthToken
+from rest_framework.response import Response
+
+from ashlar.pagination import OptionalLimitOffsetPagination
+
+from ashlar_auth.serializers import UserSerializer, GroupSerializer
+from ashlar_auth.permissions import (IsAdminOrReadSelfOnly, IsAdminOrReadOnly,
+                                     is_admin)
+
+# match what auth-service.js looks for
+USER_ID_COOKIE = 'AuthService.userId'
+TOKEN_COOKIE = 'AuthService.token'
+CAN_WRITE_COOKIE = 'AuthService.canWrite'
+ADMIN_COOKIE = 'AuthService.isAdmin'
+
+logger = logging.getLogger(__name__)
+
+
+class UserViewSet(viewsets.ModelViewSet):
+    """
+    API endpoint that allows users to be viewed or edited.
+    """
+
+    serializer_class = UserSerializer
+    permission_classes = (IsAdminOrReadSelfOnly,)
+    queryset = User.objects.all().order_by('-date_joined')
+    pagination_class = OptionalLimitOffsetPagination
+
+    def get_queryset(self):
+        """Limit non-admin users to only see their own info"""
+        user = self.request.user
+        if is_admin(user):
+            return self.queryset
+        else:
+            return self.queryset.filter(id=user.id)
+
+
+class GroupViewSet(viewsets.ModelViewSet):
+    """
+    API endpoint that allows groups to be viewed or edited.
+    """
+    queryset = Group.objects.all()
+    serializer_class = GroupSerializer
+    permission_classes = (IsAdminOrReadOnly,)
+    pagination_class = OptionalLimitOffsetPagination
+
+
+class DriverObtainAuthToken(ObtainAuthToken):
+    def post(self, request):
+        serializer = self.serializer_class(data=request.data)
+        if serializer.is_valid(raise_exception=True):
+            user = serializer.validated_data['user']
+            token, created = Token.objects.get_or_create(user=user)
+            return Response({'token': token.key, 'user': token.user_id})
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
+obtain_auth_token = DriverObtainAuthToken.as_view()

--- a/ashlar_server/__init__.py
+++ b/ashlar_server/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'ashlar_server.apps.AshlarServerConfig'

--- a/ashlar_server/apps.py
+++ b/ashlar_server/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class AshlarServerConfig(AppConfig):
+    name = 'ashlar_server'
+    verbose_name = 'Ashlar Server'

--- a/ashlar_server/settings.py
+++ b/ashlar_server/settings.py
@@ -1,0 +1,165 @@
+"""
+Django settings for ashlar_server project.
+"""
+
+# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
+import os
+
+import django
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Retrieve secret variables from the environment, defined in the .env file.
+SECRET_KEY = os.environ.get('SECRET_KEY', 'extra-secret')
+
+# Check for allowed hosts, defined as a comma-separated bash string in the
+# .env file.
+ALLOWED_HOSTS = [path for path in os.environ.get('ALLOWED_HOSTS', '').split(',') if path]
+
+# DEBUG and DEVELOP default to false. They should be represented as Pythonic
+# booleans in the .env file (i.e. caps first), but allow them to be lower case just
+# in case.
+DEBUG = False
+if os.environ.get('DEBUG') and os.environ.get('DEBUG').lower() == 'true':
+    DEBUG = True
+
+DEVELOP = False
+if os.environ.get('DEVELOP') and os.environ.get('DEVELOP').lower() == 'true':
+    DEVELOP = True
+
+# Application definition
+
+INSTALLED_APPS = (
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+    'rest_framework',
+    'rest_framework.authtoken',
+    'django_extensions',
+    'ashlar',
+    'ashlar_server',
+    'ashlar_auth',
+    'corsheaders',
+    'rest_framework_gis',
+)
+
+MIDDLEWARE = [
+    'corsheaders.middleware.CorsMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'django.middleware.security.SecurityMiddleware',
+]
+
+ROOT_URLCONF = 'ashlar_server.urls'
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]
+
+# Default database variables correspond to the development database set up
+# in docker-compose.yml
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.contrib.gis.db.backends.postgis',
+        'NAME': os.environ.get('DB_NAME', 'postgres'),
+        'USER': os.environ.get('DB_USER', 'postgres'),
+        'HOST': os.environ.get('DB_HOST', 'db'),
+        'PASSWORD': os.environ.get('DB_PASS', ''),
+        'PORT': os.environ.get('DB_PORT', '5432')
+    }
+}
+
+WSGI_APPLICATION = 'ashlar_server.wsgi.application'
+
+# Password validation
+# https://docs.djangoproject.com/en/1.11/ref/settings/#auth-password-validators
+
+AUTH_PASSWORD_VALIDATORS = [
+    {
+        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
+    },
+]
+
+# Internationalization
+# https://docs.djangoproject.com/en/1.11/topics/i18n/
+
+LANGUAGE_CODE = 'en-us'
+
+TIME_ZONE = 'UTC'
+
+USE_I18N = True
+
+USE_L10N = True
+
+USE_TZ = True
+
+# Static files (CSS, JavaScript, Images)
+# https://docs.djangoproject.com/en/1.11/howto/static-files/
+
+STATIC_URL = '/static/'
+
+if DEBUG:
+    CORS_ORIGIN_ALLOW_ALL = True
+else:
+    # Allow CORS requests only from the loopback interface
+    CORS_ORIGIN_REGEX_WHITELIST = (
+        r'^http://127.0.0.1:\d+',
+        r'^http://localhost:\d+'
+    )
+
+# Configure Django REST Framework authentication settings
+REST_FRAMEWORK = {
+    # NB: session auth must appear before token auth for both to work.
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework.authentication.SessionAuthentication',
+        'rest_framework.authentication.TokenAuthentication',
+    ),
+    'DEFAULT_PERMISSION_CLASSES': (
+        'rest_framework.permissions.AllowAny',
+    ),
+    'DEFAULT_FILTER_BACKENDS': ('django_filters.rest_framework.DjangoFilterBackend','rest_framework.filters.OrderingFilter'),
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
+    'PAGE_SIZE': 10,
+}
+
+# Ashlar authentication settings
+DEFAULT_ADMIN_EMAIL = os.environ.get("ASHLAR_ADMIN_EMAIL", 'systems+ashlar@azavea.com')
+DEFAULT_ADMIN_USERNAME = os.environ.get("ASHLAR_ADMIN_USERNAME", 'admin')
+DEFAULT_ADMIN_PASSWORD = os.environ.get("ASHLAR_ADMIN_PASSWORD", 'admin')
+USER_GROUPS = {
+    'READ_ONLY': os.environ.get('ASHLAR_READ_ONLY_GROUP', 'public'),
+    'READ_WRITE': os.environ.get('ASHLAR_READ_WRITE_GROUP', 'staff'),
+    'ADMIN': os.environ.get('ASHLAR_ADMIN_GROUP', 'admin')
+}
+
+# Ashlar-specific global variables
+ASHLAR = { 'SRID': 4326 }

--- a/ashlar_server/urls.py
+++ b/ashlar_server/urls.py
@@ -1,0 +1,37 @@
+"""ashlar_server URL Configuration
+
+The `urlpatterns` list routes URLs to views. For more information please see:
+    https://docs.djangoproject.com/en/1.8/topics/http/urls/
+Examples:
+Function views
+    1. Add an import:  from my_app import views
+    2. Add a URL to urlpatterns:  url(r'^$', views.home, name='home')
+Class-based views
+    1. Add an import:  from other_app.views import Home
+    2. Add a URL to urlpatterns:  url(r'^$', Home.as_view(), name='home')
+Including another URLconf
+    1. Add an import:  from blog import urls as blog_urls
+    2. Add a URL to urlpatterns:  url(r'^blog/', include(blog_urls))
+"""
+from django.conf.urls import include, url
+from django.contrib import admin
+
+from rest_framework import routers
+from ashlar.urls import urlpatterns as ashlar_urlpatterns
+
+import ashlar_auth.views as auth_views
+
+
+router = routers.DefaultRouter()
+
+router.register(r'users', auth_views.UserViewSet)
+router.register(r'groups', auth_views.GroupViewSet)
+
+# Register default Ashlar URLs
+urlpatterns = ashlar_urlpatterns
+
+# Add authentication routes
+urlpatterns += [
+    url(r'^api-token-auth/', auth_views.obtain_auth_token),
+    url(r'^api/', include(router.urls)),
+]

--- a/ashlar_server/wsgi.py
+++ b/ashlar_server/wsgi.py
@@ -1,0 +1,16 @@
+"""
+WSGI config for ashlar_server project.
+
+It exposes the WSGI callable as a module-level variable named ``application``.
+
+For more information on this file, see
+https://docs.djangoproject.com/en/1.8/howto/deployment/wsgi/
+"""
+
+import os
+
+from django.core.wsgi import get_wsgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "ashlar_server.settings")
+
+application = get_wsgi_application()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3'
+
+services:
+
+  db:
+    image: quay.io/azavea/postgis:2.4-postgres10.3-slim
+
+  ashlar:
+    build: .
+    depends_on:
+      - db
+    volumes:
+      - .:/opt/ashlar-server
+    entrypoint: python
+    command: manage.py runserver 0.0.0.0:8000
+    ports:
+      - "8000:8000"
+    env_file: .env
+    environment:
+      - PYTHONUNBUFFERED=0  # Do not buffer output (allows Docker to stream stdout)

--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+import os
+import sys
+
+if __name__ == "__main__":
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "ashlar_server.settings")
+    try:
+        from django.core.management import execute_from_command_line
+    except ImportError:
+        # The above import may fail for some other reason. Ensure that the
+        # issue is really that Django is missing to avoid masking other
+        # exceptions on Python 2.
+        try:
+            import django
+        except ImportError:
+            raise ImportError(
+                "Couldn't import Django. Are you sure it's installed and "
+                "available on your PYTHONPATH environment variable? Did you "
+                "forget to activate a virtual environment?"
+            )
+        raise
+    execute_from_command_line(sys.argv)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+git+https://github.com/azavea/ashlar.git@develop#egg=ashlar
+django-cors-headers==2.2.0

--- a/scripts/_config.sh
+++ b/scripts/_config.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# _config.sh -- common config settings for dev scripts
+
+# If an unhandled command returns a non-zero exit code, stop the script.
+set -e
+
+# If the user has set the ASHLAR_DEBUG variable to any value, run
+# this script in debug mode (print all commands before they run).
+if [[ -n "${ASHLAR_DEBUG}" ]]; then
+    set -x
+fi
+
+# Trap Ctrl+C signals and make sure they kill all running containers.
+trap "docker-compose stop" SIGINT SIGTERM

--- a/scripts/_init_db.sh
+++ b/scripts/_init_db.sh
@@ -1,0 +1,26 @@
+function init_db() {
+    #
+    # Start the database service and poll it until it becomes available. Useful
+    # for services that rely on the database, since by default Docker considers
+    # a dependency service to have been satisfied when the container starts
+    # up, not when its command has actually completed.
+    #
+    docker-compose up -d db
+    INIT_COUNTER=15
+    COUNTER=$INIT_COUNTER
+    until
+        [ $(docker-compose exec db pg_isready -d postgres -h "0.0.0.0" -p 5432 > /dev/null 2>&1 && echo $? || echo 1) -eq 0 ] ||
+        [ $COUNTER -eq 0 ];
+    do
+        echo "Database unavailable -- attempting to connect (${COUNTER} attempts remaining)"
+        COUNTER=$((COUNTER-1))
+        sleep 1
+    done
+
+    if [ $COUNTER -eq 0 ];
+    then
+        echo "ERROR: Database service failed to start after ${INIT_COUNTER} seconds."
+        echo "Adjust the timeout by increasing the INIT_COUNTER variable in scripts/server."
+        exit 1
+    fi
+}

--- a/scripts/clean
+++ b/scripts/clean
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Most reliable way to get the path for this script.
+# h/t: https://stackoverflow.com/questions/192292/bash-how-best-to-include-other-scripts/12694189#12694189
+DIR="${BASH_SOURCE%/*}"
+if [[ ! -d "$DIR" ]];
+then
+    DIR="$PWD"
+fi
+
+# Load common configs for this script.
+source "${DIR}/_config.sh"
+
+function usage() {
+    echo -n "Usage: $(basename "$0")
+
+Clean up unused Docker resources to free disk space.
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+    else
+        # Stop containers and shut down the network
+        docker-compose down
+
+        # Remove unused containers, images, and volumes
+        docker system prune -f
+    fi
+fi

--- a/scripts/sample_data/sample_data.json
+++ b/scripts/sample_data/sample_data.json
@@ -1,0 +1,287 @@
+[
+    {
+        "label": "Incident",
+        "plural_label": "Incidents",
+        "description": "Description of an incident.",
+        "active": true,
+        "schema": {
+            "schema": {
+                "description": "",
+                "title": "",
+                "plural_title": "",
+                "definitions": {
+                    "driverIncidentDetails": {
+                        "multiple": false,
+                        "description": "Details for Incident",
+                        "title": "Incident Details",
+                        "required": [
+                            "_localId"
+                        ],
+                        "plural_title": "Incident Details",
+                        "propertyOrder": 0,
+                        "details": true,
+                        "definitions": {},
+                        "type": "object",
+                        "properties": {
+                            "Select List": {
+                                "enum": [
+                                    "Foo",
+                                    "Bar",
+                                    "Baz"
+                                ],
+                                "displayType": "select",
+                                "propertyOrder": 1,
+                                "fieldType": "selectlist",
+                                "isSearchable": true,
+                                "type": "string"
+                            },
+                            "Extra description": {
+                                "isSearchable": true,
+                                "propertyOrder": 0,
+                                "type": "string",
+                                "fieldType": "text",
+                                "format": "textarea"
+                            },
+                            "_localId": {
+                                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+                                "type": "string",
+                                "options": {
+                                    "hidden": true
+                                }
+                            }
+                        }
+                    }
+                },
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "type": "object",
+                "properties": {
+                    "driverIncidentDetails": {
+                        "options": {
+                            "collapsed": true
+                        },
+                        "$ref": "#/definitions/driverIncidentDetails"
+                    }
+                }
+            },
+            "version": 1,
+            "next_version": null,
+            "records": [
+                {
+                    "data": {
+                        "driverIncidentDetails": {
+                            "Select List": "Foo",
+                            "Extra description": "Lorem ipsum dolor sit amet.",
+                            "_localId": "d808a3f9-512a-4cc3-b6ba-e098db8b0319"
+                        }
+                    },
+                    "occurred_from": "2018-03-21T18:03:00Z",
+                    "occurred_to": "2018-03-21T18:03:00Z",
+                    "geom": {
+                        "type": "Point",
+                        "coordinates": [
+                            -75.14150619506836,
+                            39.95354329351782
+                        ]
+                    },
+                    "location_text": null,
+                    "city": null,
+                    "city_district": null,
+                    "county": null,
+                    "neighborhood": null,
+                    "road": null,
+                    "state": null,
+                    "weather": null,
+                    "light": null,
+                    "archived": false
+                },
+                {
+                    "data": {
+                        "driverIncidentDetails": {
+                            "Select List": "Bar",
+                            "Extra description": "Incident three.",
+                            "_localId": "f97b2db1-084c-4f82-b514-2a550621b8fa"
+                        }
+                    },
+                    "occurred_from": "2018-05-22T18:01:00Z",
+                    "occurred_to": "2018-05-22T18:01:00Z",
+                    "geom": {
+                        "type": "Point",
+                        "coordinates": [
+                            -75.17491579055786,
+                            39.89911591011025
+                        ]
+                    },
+                    "location_text": null,
+                    "city": null,
+                    "city_district": null,
+                    "county": null,
+                    "neighborhood": null,
+                    "road": null,
+                    "state": null,
+                    "weather": null,
+                    "light": null,
+                    "archived": false
+                },
+                {
+                    "data": {
+                        "driverIncidentDetails": {
+                            "Select List": "Baz",
+                            "Extra description": "Another incident.",
+                            "_localId": "ba3520af-f71b-4889-9fda-f27077ab79b5"
+                        }
+                    },
+                    "created": "2018-06-21T18:01:30.331307Z",
+                    "modified": "2018-06-21T18:01:30.331328Z",
+                    "occurred_from": "2018-06-04T18:00:00Z",
+                    "occurred_to": "2018-06-04T18:00:00Z",
+                    "geom": {
+                        "type": "Point",
+                        "coordinates": [
+                            -75.16080737113953,
+                            39.96515674205093
+                        ]
+                    },
+                    "location_text": null,
+                    "city": null,
+                    "city_district": null,
+                    "county": null,
+                    "neighborhood": null,
+                    "road": null,
+                    "state": null,
+                    "weather": null,
+                    "light": null,
+                    "archived": false
+                },
+                {
+                    "data": {
+                        "driverIncidentDetails": {
+                            "Select List": "Foo",
+                            "Extra description": "Here's where description for an incident should go.",
+                            "_localId": "95f3fe51-4360-4260-8ce3-40b87b289205"
+                        }
+                    },
+                    "created": "2018-06-21T17:58:58.017764Z",
+                    "modified": "2018-06-21T17:58:58.017785Z",
+                    "occurred_from": "2018-06-19T17:58:00Z",
+                    "occurred_to": "2018-06-19T17:58:00Z",
+                    "geom": {
+                        "type": "Point",
+                        "coordinates": [
+                            -75.18635272979736,
+                            39.933795415406095
+                        ]
+                    },
+                    "location_text": null,
+                    "city": null,
+                    "city_district": null,
+                    "county": null,
+                    "neighborhood": null,
+                    "road": null,
+                    "state": null,
+                    "weather": null,
+                    "light": null,
+                    "archived": false
+                }
+            ]
+        }
+    },
+    {
+        "label": "Intervention",
+        "plural_label": "Interventions",
+        "description": "A second sample record type.",
+        "active": true,
+        "schema": {
+            "schema": {
+                "description": "",
+                "title": "",
+                "plural_title": "",
+                "definitions": {
+                    "driverInterventionDetails": {
+                        "multiple": false,
+                        "description": "Details for Intervention",
+                        "title": "Intervention Details",
+                        "required": [
+                            "_localId"
+                        ],
+                        "plural_title": "Intervention Details",
+                        "propertyOrder": 0,
+                        "details": true,
+                        "definitions": {},
+                        "type": "object",
+                        "properties": {
+                            "Select List": {
+                                "enum": [
+                                    "Foo",
+                                    "Bar",
+                                    "Baz"
+                                ],
+                                "displayType": "select",
+                                "propertyOrder": 0,
+                                "fieldType": "selectlist",
+                                "isSearchable": true,
+                                "type": "string"
+                            },
+                            "Number field": {
+                                "maximum": 100,
+                                "minimum": 0,
+                                "propertyOrder": 1,
+                                "fieldType": "number",
+                                "isSearchable": true,
+                                "type": "number"
+                            },
+                            "Text Field": {
+                                "isSearchable": true,
+                                "propertyOrder": 2,
+                                "type": "string",
+                                "fieldType": "text",
+                                "format": "text"
+                            },
+                            "_localId": {
+                                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+                                "type": "string",
+                                "options": {
+                                    "hidden": true
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "version": 1,
+            "next_version": null,
+            "records": [
+                {
+                    "uuid": "0bac7803-96b1-41ed-a7b4-d73c5074b40d",
+                    "data": {
+                        "driverInterventionDetails": {
+                            "Select List": "Foo",
+                            "Number field": 5,
+                            "Text Field": ""
+                        }
+                    },
+                    "created": "2018-06-26T17:54:55.733637Z",
+                    "modified": "2018-06-26T17:54:55.733657Z",
+                    "occurred_from": "2018-06-26T17:54:14.848000Z",
+                    "occurred_to": "2018-06-26T17:54:14.848000Z",
+                    "geom": {
+                        "type": "Point",
+                        "coordinates": [
+                            -75.16376852989197,
+                            39.95185070207273
+                        ]
+                    },
+                    "location_text": null,
+                    "city": null,
+                    "city_district": null,
+                    "county": null,
+                    "neighborhood": null,
+                    "road": null,
+                    "state": null,
+                    "weather": null,
+                    "light": null,
+                    "archived": false
+                }
+            ]
+        }
+    }
+]

--- a/scripts/server
+++ b/scripts/server
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+# Most reliable way to get the path for this script.
+# h/t: https://stackoverflow.com/questions/192292/bash-how-best-to-include-other-scripts/12694189#12694189
+DIR="${BASH_SOURCE%/*}"
+if [[ ! -d "$DIR" ]];
+then
+    DIR="$PWD"
+fi
+
+# Load common configs for this script.
+source "${DIR}/_config.sh"
+
+# Import DB initialization methods.
+source "${DIR}/_init_db.sh"
+
+function usage() {
+    echo -n "Usage: $(basename "$0") {ashlar} [CMD]
+
+Starts servers using docker-compose. If an argument is specified, [CMD]
+will pass the command string into the corresponding service.
+
+Argument options:
+    - ashlar: Starts the Ashlar database server on port 8000.
+    - <none>: Start all services.
+"
+}
+
+# The name of the Ashlar service to search for when checking if it's running
+# (e.g. <repo-name>_ashlar)
+ASHLAR_GREP="server_ashlar"
+
+function checkport() {
+    #
+    # Check that a given port has no processes running on it.
+    #
+    if [[ $(netstat -nlp | grep ":::${1}") ]];
+    then
+        echo "It appears you already have a process running on port ${1}:"
+        echo
+        echo $(netstat -nlp | grep ":::${1}")
+        echo
+        echo "Terminate that process, or alter docker-compose.yml to use another port."
+        exit 1
+    fi
+}
+
+function run_ashlar_service() {
+    #
+    # Run the Ashlar server instance.
+    #
+    if [ $(docker-compose ps | grep "${ASHLAR_GREP}" | grep -q "Up" && echo "$?" || echo 1) -eq 0 ];
+    then
+        echo "Ashlar service is already running."
+    else
+        checkport 8000
+        init_db
+        if [ $# -eq 0 ];
+        then
+            # No arguments -- default to running a Django dev server
+            docker-compose up ashlar
+        else
+            if [ "$1" = "detached"  ];
+            then
+                # Run this service in the background
+                docker-compose up -d ashlar
+            else
+                # User passed in arguments -- run their command
+                docker-compose run --rm --service-ports ashlar "$@"
+            fi
+        fi
+    fi
+}
+
+function run_all_services() {
+    #
+    # Run all services in docker-compose.yml (the managed equivalent of
+    # `docker-compose up`).
+    #
+    run_ashlar_service
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]
+then
+    if [ -z "$1" ]
+    then
+        # If no arguments are supplied, start all services.
+        function runserver() {
+            run_all_services
+        }
+    else
+        case "$1" in
+            -h|--help)
+                usage
+                exit 0
+                ;;
+
+            ashlar)
+                shift 1
+                function runserver() {
+                    run_ashlar_service "$@"
+                }
+                ;;
+
+            *)
+                echo "ERROR: Container type '"$1"' not found."
+                echo
+                usage
+                exit 1
+                ;;
+        esac
+    fi
+    runserver "$@"
+fi

--- a/scripts/test
+++ b/scripts/test
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+# Most reliable way to get the path for this script.
+# h/t: https://stackoverflow.com/questions/192292/bash-how-best-to-include-other-scripts/12694189#12694189
+DIR="${BASH_SOURCE%/*}"
+if [[ ! -d "$DIR" ]];
+then
+    DIR="$PWD"
+fi
+
+# Load common configs for this script.
+source "${DIR}/_config.sh"
+
+# Load database initialization procedure
+source "${DIR}/_init_db.sh"
+
+function usage() {
+    echo -n "Usage: $(basename "$0") {git,ashlar} [VERSIONS]
+Run tests.
+
+Options:
+    -h --help       Display this help text
+    git             Check git commit titles
+    ashlar          Run tests for the app, optionally limited to Python/Django VERSIONS
+    <none>          Run all tests
+
+Versions:
+    When running tests for the app, you can limit the Python/Django versions you'd like
+    to test in order to speed up test execution. For example, the following command will only
+    run tests for Python 3.4 and Django 1.11:
+
+        ./scripts/test app py34-django111
+
+    To view available versions, see the envlist in the tox.ini file at the root of
+    this repo.
+"
+}
+
+function ashlar_tests() {
+    echo "Testing the app..."
+    echo "-------------------------------------------------------------------"
+
+    init_db
+
+    if [ -z "$1" ]
+    then
+        # No arguments -- default to running all tests
+        docker-compose run --rm ashlar manage.py test
+    else
+        # Run tests for the environment that the user has passed in
+        docker-compose run --rm test tox -e "$1"
+    fi
+
+    # Stop the database service so that containers aren't lying around
+    docker-compose stop db
+
+    echo "PASSED: app tests passed."
+
+}
+
+function git_tests() {
+    # Fail build if any commit title in this branch contains these words
+    echo "Making sure that all commits in this branch are clean..."
+    echo "-------------------------------------------------------------------"
+    if git log --oneline master.. | grep -wiE "fixup|squash|wip"
+    then
+        echo "FAILED: Illegal words in git commit:"
+        echo
+        echo $(git log --oneline master.. | grep -wiE "fixup|squash|wip")
+        echo
+        echo "Please squash these changes before merging."
+        exit 1
+    else
+        echo "PASSED: Git commits are clean."
+    fi
+}
+
+function all_tests() {
+    echo "Running all tests..."
+    echo "-------------------------------------------------------------------"
+    ashlar_tests
+    echo "-------------------------------------------------------------------"
+    git_tests
+    echo "-------------------------------------------------------------------"
+    echo "PASSED: All tests passed."
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ -z "$1" ]
+    then
+        # If no arguments are supplied, run app tests.
+        all_tests
+    else
+        case "${1:-}" in
+            -h|--help) usage ;;
+            git)       git_tests ;;
+            ashlar)    shift 1 && ashlar_tests "$@" ;;
+            *)         usage ;;
+        esac
+    fi
+fi

--- a/scripts/test
+++ b/scripts/test
@@ -41,15 +41,7 @@ function ashlar_tests() {
     echo "-------------------------------------------------------------------"
 
     init_db
-
-    if [ -z "$1" ]
-    then
-        # No arguments -- default to running all tests
-        docker-compose run --rm ashlar manage.py test
-    else
-        # Run tests for the environment that the user has passed in
-        docker-compose run --rm test tox -e "$1"
-    fi
+    docker-compose run --rm ashlar manage.py test
 
     # Stop the database service so that containers aren't lying around
     docker-compose stop db

--- a/scripts/update
+++ b/scripts/update
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Most reliable way to get the path for this script.
+# h/t: https://stackoverflow.com/questions/192292/bash-how-best-to-include-other-scripts/12694189#12694189
+DIR="${BASH_SOURCE%/*}"
+if [[ ! -d "$DIR" ]];
+then
+    DIR="$PWD"
+fi
+
+# Load common configs for this script.
+source "${DIR}/_config.sh"
+
+# Import DB initialization methods.
+source "${DIR}/_init_db.sh"
+
+function usage() {
+    echo -n "Usage: $(basename "$0")
+
+Make sure containers are up to date.
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]
+then
+    if [ "${1:-}" = "--help" ]
+    then
+        usage
+    else
+        # Build containers.
+        docker-compose build
+
+        # Run migrations.
+        init_db
+        docker-compose run --rm ashlar manage.py migrate
+
+        # Stop all services.
+        docker-compose stop
+    fi
+fi


### PR DESCRIPTION
# Overview

This PR pulls out the relevant components of the Ashlar server from https://github.com/azavea/ashlar-blueprint and brings them into this repo.

## Notes

- Most of this code is ported from https://github.com/azavea/ashlar-blueprint with just a few small modifications to get it to work in Django 1.11. As such, I don't expect a detailed code review.

- How exactly we should recommend that a developer deploy/provision this repo in another project is still a bit hazy for me. My instinct for the immediate future is to include it as a [git subtree](https://www.atlassian.com/blog/git/alternatives-to-git-submodule-git-subtree) in my demo app and orchestrate the container with Docker Compose; this has the advantages of A) being a development pattern that's now familiar to me and B) allowing me to push any changes I make back upstream to this repo, but it seems like it won't be the most useful pattern for deploying to production, or for helping other developers use the repo. It'd probably be useful to have a high-level conversation about approaches to packaging apps like this soon.

## Testing instructions

- Travis will run all unit tests for the authentication module. To run these locally, use the development scripts:

```
# Use default environmental variables
cp .env.example .env

# Pull and build containers, run migrations
./scripts/update

# Run tests
./scripts/test
```

- To confirm that the server is running, run `./scripts/server`. Then, navigate to `127.0.0.1:8000/api` to confirm that the API loads properly.