### PR TITLE
Update configs

### DIFF
--- a/grout_server/settings.py
+++ b/grout_server/settings.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = (
     'rest_framework',
     'rest_framework.authtoken',
     'django_extensions',
+    'django_filters',
     'grout',
     'grout_server',
     'grout_auth',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/azavea/grout.git@develop#egg=ashlar
+git+https://github.com/azavea/grout.git@develop#egg=grout
 django-cors-headers==2.2.0


### PR DESCRIPTION
# Overview

While debugging some issues with https://github.com/jeancochrane/philly-fliers/pull/1, I noticed that two configuration options were off in this repo. These cause problems that don't  break core functionality, but that are annoying:

1. The pip egg installs with the wrong package name, and complains loudly
2. Some API endpoints can't load templates in a browser, since `django_filters` is not loaded properly

This PR makes a quick fix for those configuration issues.

## Testing

- Travis will run unit tests to confirm that everything still works. You can run unit tests locally by running `./scripts/test`.

- For an example of an endpoint that wasn't showing up properly, try visiting [http:localhost:8000/api/records](http:localhost:8000/api/records) after starting a server:

```
./scripts/update
./scripts/server
```

