### PR TITLE
Allow alternate deployment configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,7 @@ DEBUG=True
 # Comma-separated string of hosts that are allowed to serve the app. When
 # DEBUG=True this can be empty. For more context, see the docs:
 # https://docs.djangoproject.com/en/dev/ref/settings/#allowed-hosts
-ALLOWED_HOSTS=
+ALLOWED_HOSTS=grout,localhost,127.0.0.1
 
 # Comma-separated string of additional apps to register.
 INSTALLED_APPS=

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# .env.example -- Example environmental variables for an Grout server project.
+# .env.example -- Example environmental variables for a Grout server project.
 # To override any of these variables, copy this file to .env and make sure that whatever
 # runs your process (e.g. Docker Compose or supervisord) knows to load these
 # variables into the environment.
@@ -13,6 +13,9 @@ DEBUG=True
 # DEBUG=True this can be empty. For more context, see the docs:
 # https://docs.djangoproject.com/en/dev/ref/settings/#allowed-hosts
 ALLOWED_HOSTS=
+
+# Comma-separated string of additional apps to register.
+INSTALLED_APPS=
 
 # Special flag to tell Grout whether or not you're developing locally.
 DEVELOP=True

--- a/.env.s3.example
+++ b/.env.s3.example
@@ -1,0 +1,16 @@
+# .env.s3.example -- Example environmental variables for deploying a Grout
+# server using S3 as the static file backend.
+# To override any of these variables, copy this file to .env and make sure that whatever
+# runs your process (e.g. Docker Compose or supervisord) knows to load these
+# variables into the environment.
+
+# Add django-storages as an installed app.
+INSTALLED_APPS=storages
+
+# Required configs for django-storages S3 backend.
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_STORAGE_BUCKET_NAME=
+
+# Append this path location to all S3 requests.
+AWS_LOCATION=

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,8 @@ coverage.xml
 # Django stuff:
 *.log
 local_settings.py
+settings_deployment.py
+setting
 db.sqlite3
 
 # Sphinx documentation

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ sudo: required
 services:
   - docker
 
-before_install:
-  - cp .env.example .env
-
 install:
   - ./scripts/update
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ sudo: required
 services:
   - docker
 
+before_install:
+  - cp .env.example .env
+
 install:
   - ./scripts/update
 

--- a/README.md
+++ b/README.md
@@ -60,3 +60,29 @@ To run the tests, use the `test` script:
 # In the grout-server repo:
 ./scripts/test
 ```
+
+## Deployment
+
+You can define extra Django settings for your deployment in an optional config
+file, `grout_server/settings_deployment.py`. The project settings file will attempt to import
+all settings from this config, and if the file doesn't exist it will skip the
+import.
+
+An example deployment config file is provided in
+`grout_server/settings.s3.py`, which defines extra configuration settings for
+serving static files from AWS S3 using the [django-storages
+backend](https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html).
+To use this file for your deployment, copy it to the path that the settings
+file expects:
+
+```bash
+cp grout_server/settings.s3.py grout_server/settings_deployment.py
+```
+
+If you use the S3 settings file, make sure to update your environmental variables
+according to the template provided in `.env.s3.example` in order to load the
+appropriate login credentials.
+
+For a step-by-step guide to setting up the necessary configuration on the S3
+side, see [Victor Freitas' blog post on setting up S3 to serve Django static
+files](https://simpleisbetterthancomplex.com/tutorial/2017/08/01/how-to-setup-amazon-s3-in-a-django-project.html).

--- a/grout_auth/permissions.py
+++ b/grout_auth/permissions.py
@@ -118,6 +118,21 @@ class ReadersReadWritersWrite(permissions.BasePermission):
         return False
 
 
+class PublicReadsWritersWrite(permissions.BasePermission):
+    """
+    Allow read-only access to the readers group, as well as all guest (unauthenticated)
+    users. Allow full access to writers or admins.
+    """
+    def has_permission(self, request, view):
+        return (
+            request.method in permissions.SAFE_METHODS or (
+                request.user and
+                request.user.is_authenticated() and
+                is_admin_or_writer(request.user)
+            )
+        )
+
+
 class IsOwnerOrAdmin(permissions.BasePermission):
     """Allow access only to the user who created the object, and admins"""
     def has_object_permission(self, request, view, obj):

--- a/grout_server/settings.py
+++ b/grout_server/settings.py
@@ -152,7 +152,7 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.TokenAuthentication',
     ),
     'DEFAULT_PERMISSION_CLASSES': (
-        'rest_framework.permissions.IsAuthenticatedOrReadOnly',
+        'grout_auth.permissions.PublicReadsWritersWrite',
     ),
     'DEFAULT_FILTER_BACKENDS': ('django_filters.rest_framework.DjangoFilterBackend','rest_framework.filters.OrderingFilter'),
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',

--- a/grout_server/settings.py
+++ b/grout_server/settings.py
@@ -47,6 +47,12 @@ INSTALLED_APPS = (
     'rest_framework_gis',
 )
 
+# Check for extra apps, defined as a comma-separated bash string in the
+# .env file.
+EXTRA_APPS = tuple(app for app in os.environ.get('INSTALLED_APPS', '').split(',') if app)
+
+INSTALLED_APPS += EXTRA_APPS
+
 MIDDLEWARE = [
     'corsheaders.middleware.CorsMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -126,6 +132,7 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.11/howto/static-files/
 
+STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 STATIC_URL = '/static/'
 
 if DEBUG:
@@ -164,3 +171,10 @@ USER_GROUPS = {
 
 # Grout-specific global variables
 GROUT = { 'SRID': 4326 }
+
+# Try to import extra deployment-specific settings.
+if DEBUG is False:
+    try:
+        from grout_server.settings_deployment import *
+    except ImportError:
+        pass

--- a/grout_server/settings.py
+++ b/grout_server/settings.py
@@ -152,7 +152,7 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.TokenAuthentication',
     ),
     'DEFAULT_PERMISSION_CLASSES': (
-        'rest_framework.permissions.AllowAny',
+        'rest_framework.permissions.IsAuthenticatedOrReadOnly',
     ),
     'DEFAULT_FILTER_BACKENDS': ('django_filters.rest_framework.DjangoFilterBackend','rest_framework.filters.OrderingFilter'),
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',

--- a/grout_server/settings.s3.py
+++ b/grout_server/settings.s3.py
@@ -1,0 +1,32 @@
+"""
+Extra Django settings for a grout_server deployment using AWS S3 for serving
+static files with django-storages.
+
+For documentation on each of the settings, see:
+https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html
+"""
+
+import os
+
+
+# Required django-storages settings.
+STATICFILES_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
+AWS_ACCESS_KEY_ID = os.environ.get('AWS_ACCESS_KEY_ID', '')
+AWS_SECRET_ACCESS_KEY = os.environ.get('AWS_SECRET_ACCESS_KEY', '')
+AWS_STORAGE_BUCKET_NAME = os.environ.get('AWS_STORAGE_BUCKET_NAME', '')
+AWS_S3_CUSTOM_DOMAIN = '{bucket}.s3.amazonaws.com'.format(bucket=AWS_STORAGE_BUCKET_NAME)
+
+# Optional django-storages settings -- remove or extend these at will.
+AWS_LOCATION = os.environ.get('AWS_LOCATION', '')
+AWS_S3_OBJECT_PARAMETERS = {
+    'CacheControl': 'max-age=86400',
+}
+AWS_S3_FILE_OVERWRITE = False
+AWS_IS_GZIPPED = True
+
+# Static files settings.
+if AWS_LOCATION:
+    STATIC_URL = 'https://{host}/{location}/'.format(host=AWS_S3_CUSTOM_DOMAIN,
+                                                     location=AWS_LOCATION)
+else:
+    STATIC_URL = 'https://{host}/'.format(host=AWS_S3_CUSTOM_DOMAIN)

--- a/grout_server/urls.py
+++ b/grout_server/urls.py
@@ -34,4 +34,5 @@ urlpatterns = grout_urlpatterns
 urlpatterns += [
     url(r'^api-token-auth/', auth_views.obtain_auth_token),
     url(r'^api/', include(router.urls)),
+    url(r'^api/token-auth/', auth_views.obtain_auth_token),
 ]

--- a/grout_server/urls.py
+++ b/grout_server/urls.py
@@ -34,5 +34,5 @@ urlpatterns = grout_urlpatterns
 urlpatterns += [
     url(r'^api-token-auth/', auth_views.obtain_auth_token),
     url(r'^api/', include(router.urls)),
-    url(r'^api/token-auth/', auth_views.obtain_auth_token),
+    url(r'^api/auth/token/post/', auth_views.obtain_auth_token),
 ]


### PR DESCRIPTION
# Overview

This PR extends the app's settings to permit alternative deployment configurations. These changes were made in order to facilitate deploying the demo app in https://github.com/jeancochrane/philly-fliers/pull/2.

## Notes

- The most important change made here is allowing extra `INSTALLED_APPS` to be defined in the environment, and also loading in deployment configs from an optional `settings_deployment` module when `DEBUG` is `False`. In the demo app, we leverage these two changes to deploy static assets to AWS S3; sample configs for how to do that are provided in this PR, along with some documentation in the README.

## Testing instructions

This PR introduces no new unit tests. To run older tests and confirm no regressions, use the `test` script:

```bash
# Update containers.
./scripts/update

# Run unit tests.
./scripts/test
```