### PR TITLE
 Default to read-only permissions and add new token route to Grout Server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ sudo: required
 services:
   - docker
 
-before_install:
-  - cp .env.example .env
-
 install:
   - ./scripts/update
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ sudo: required
 services:
   - docker
 
+before_install:
+  - cp .env.example .env
+
 install:
   - ./scripts/update
 

--- a/grout_auth/permissions.py
+++ b/grout_auth/permissions.py
@@ -118,6 +118,21 @@ class ReadersReadWritersWrite(permissions.BasePermission):
         return False
 
 
+class PublicReadsWritersWrite(permissions.BasePermission):
+    """
+    Allow read-only access to the readers group, as well as all guest (unauthenticated)
+    users. Allow full access to writers or admins.
+    """
+    def has_permission(self, request, view):
+        return (
+            request.method in permissions.SAFE_METHODS or (
+                request.user and
+                request.user.is_authenticated() and
+                is_admin_or_writer(request.user)
+            )
+        )
+
+
 class IsOwnerOrAdmin(permissions.BasePermission):
     """Allow access only to the user who created the object, and admins"""
     def has_object_permission(self, request, view, obj):

--- a/grout_server/settings.py
+++ b/grout_server/settings.py
@@ -152,7 +152,7 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.TokenAuthentication',
     ),
     'DEFAULT_PERMISSION_CLASSES': (
-        'rest_framework.permissions.IsAuthenticatedOrReadOnly',
+        'grout_auth.permissions.PublicReadsWritersWrite',
     ),
     'DEFAULT_FILTER_BACKENDS': ('django_filters.rest_framework.DjangoFilterBackend','rest_framework.filters.OrderingFilter'),
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',

--- a/grout_server/settings.py
+++ b/grout_server/settings.py
@@ -152,7 +152,7 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.TokenAuthentication',
     ),
     'DEFAULT_PERMISSION_CLASSES': (
-        'rest_framework.permissions.AllowAny',
+        'rest_framework.permissions.IsAuthenticatedOrReadOnly',
     ),
     'DEFAULT_FILTER_BACKENDS': ('django_filters.rest_framework.DjangoFilterBackend','rest_framework.filters.OrderingFilter'),
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',

--- a/grout_server/urls.py
+++ b/grout_server/urls.py
@@ -34,4 +34,5 @@ urlpatterns = grout_urlpatterns
 urlpatterns += [
     url(r'^api-token-auth/', auth_views.obtain_auth_token),
     url(r'^api/', include(router.urls)),
+    url(r'^api/token-auth/', auth_views.obtain_auth_token),
 ]

--- a/grout_server/urls.py
+++ b/grout_server/urls.py
@@ -34,5 +34,5 @@ urlpatterns = grout_urlpatterns
 urlpatterns += [
     url(r'^api-token-auth/', auth_views.obtain_auth_token),
     url(r'^api/', include(router.urls)),
-    url(r'^api/token-auth/', auth_views.obtain_auth_token),
+    url(r'^api/auth/token/post/', auth_views.obtain_auth_token),
 ]


### PR DESCRIPTION
# Overview

This PR changes the default permissions for the Grout Server app to allow read-only access to API endpoints for unauthorized and `public` group users. It also adds a new route, `/api/auth/token/post/`, which provides the same functionality as the old `/api-token-auth/` route but can be accessed if you're proxying the server from a `location` pattern like `~ api/`.

## Demo

The easiest way to view the change is to look at the Django REST Framework frontend. Navigating the site as a guest, we can read all of the available public data:

![public-no-post](https://user-images.githubusercontent.com/14170650/43528857-eed1e058-9577-11e8-9040-bf313071290f.png)

Notice that when we log in as an admin (using the default `admin`/`admin` credentials), a `POST` form appears:

![admin-post](https://user-images.githubusercontent.com/14170650/43528884-ff446028-9577-11e8-8967-01a9ec5b3b97.png)

## Testing instructions

the `grout_auth` app has a test for the new permissions class. To run the unit tests, use the `test` script:

```bash
# Update containers and run migrations.
./scripts/update

# Run tests.
./scripts/test
```

There are no tests specific to the server itself, since it's just dropping in the new permissions class from the `grout_auth` app. However, you can confirm that behavior works as expected by running a dev server and playing around with the Django REST Framework frontend, as in the demo above:

```bash
# Run the development server.
./scripts/server
```

Closes https://github.com/azavea/grout-2018-fellowship/issues/41 and https://github.com/azavea/grout-2018-fellowship/issues/42.